### PR TITLE
fixed date formatting in startDate and dueDate fields

### DIFF
--- a/nodes/TickTick/GenericFunctions.ts
+++ b/nodes/TickTick/GenericFunctions.ts
@@ -113,7 +113,8 @@ export function formatTickTickDate(dateString: string): string | undefined {
 	// Format the main part of the date object
 	const dateTimePart = date.toFormat("yyyy-MM-dd'T'HH:mm:ss");
 
-	// Manually format the timezone offset - Luxon by default puts a ":" in the date, this format cannot be processed by TickTick
+	// Manually format the timezone offset - Luxon by default puts a ":" in the date offset part, this format cannot be processed by TickTick
+	// See https://developer.ticktick.com/api#/openapi?id=create-task
 	const offsetSign = date.offset >= 0 ? '+' : '-';
 	const offsetHours = String(Math.floor(Math.abs(date.offset) / 60)).padStart(2, '0');
 	const offsetMinutes = String(Math.abs(date.offset) % 60).padStart(2, '0');

--- a/nodes/TickTick/GenericFunctions.ts
+++ b/nodes/TickTick/GenericFunctions.ts
@@ -100,3 +100,31 @@ export const TimeZones = [
 	{ name: 'Australia/Sydney', value: 'Australia/Sydney' },
 	{ name: 'Pacific/Auckland', value: 'Pacific/Auckland' },
 ];
+
+export function formatTickTickDate(dateString: string): string | undefined {
+	if (!dateString) {
+		return undefined;
+	}
+
+	const date = new Date(dateString);
+
+	const pad = (num: number) => String(num).padStart(2, '0');
+
+	const year = date.getFullYear();
+	const month = pad(date.getMonth() + 1);
+	const day = pad(date.getDate());
+	const hours = pad(date.getHours());
+	const minutes = pad(date.getMinutes());
+	const seconds = pad(date.getSeconds());
+
+	// Calculate correct Timezone offset
+	const timezoneOffset = date.getTimezoneOffset();
+	const offsetSign = timezoneOffset > 0 ? '-' : '+';
+	const offsetHours = pad(Math.floor(Math.abs(timezoneOffset) / 60));
+	const offsetMinutes = pad(Math.abs(timezoneOffset) % 60);
+	const timezone = `${offsetSign}${offsetHours}${offsetMinutes}`;
+
+	// TickTick requires format "2019-11-13T03:00:00+0000" - "yyyy-MM-dd'T'HH:mm:ssZ"
+	// See: https://developer.ticktick.com/api#/openapi?id=create-task
+	return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}${timezone}`;
+}

--- a/nodes/TickTick/TickTick.node.ts
+++ b/nodes/TickTick/TickTick.node.ts
@@ -8,7 +8,7 @@ import {
 	NodeOperationError,
 } from 'n8n-workflow';
 
-import { tickTickApiRequest, getProjects, getTasks } from './GenericFunctions';
+import { tickTickApiRequest, getProjects, getTasks, formatTickTickDate } from './GenericFunctions';
 
 import { taskFields, taskOperations, projectFields, projectOperations } from './descriptions';
 
@@ -223,14 +223,15 @@ export class TickTick implements INodeType {
 							}
 						} else {
 							const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
+
 							body = {
 								title: this.getNodeParameter('title', i) as string,
 								projectId: this.getNodeParameter('projectId', i) as string,
 								content: (additionalFields.content as string) || undefined,
 								desc: (additionalFields.desc as string) || undefined,
 								isAllDay: (additionalFields.isAllDay as boolean) || false,
-								startDate: (additionalFields.startDate as string) || undefined,
-								dueDate: (additionalFields.dueDate as string) || undefined,
+								startDate: formatTickTickDate(additionalFields.startDate as string),
+								dueDate: formatTickTickDate(additionalFields.dueDate as string),
 								timeZone: (additionalFields.timeZone as string) || undefined,
 								priority: (additionalFields.priority as number) || 0,
 							};

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		]
 	},
 	"devDependencies": {
+		"@types/luxon": "^3.7.1",
 		"@typescript-eslint/parser": "^7.15.0",
 		"eslint": "^8.56.0",
 		"eslint-plugin-n8n-nodes-base": "^1.16.1",


### PR DESCRIPTION
## Description

This pull request resolves a bug where the `startDate` and `dueDate` were not being set correctly when creating a task. See issue #9.

## The Problem

The node was sending a date format that the TickTick API did not accept.

## The Solution
This commit resolves the issue by using the `luxon` library to reliably parse the incoming date string from n8n.
